### PR TITLE
Crh suse compatibility

### DIFF
--- a/ceph_monitoring/collect_info.py
+++ b/ceph_monitoring/collect_info.py
@@ -323,7 +323,7 @@ class NodeCollector(Collector):
         ("lsblk", "txt", "lsblk -a"),
         ("diskstats", "txt", "cat /proc/diskstats"),
         ("uname", "txt", "uname -a"),
-        ("dmidecode", "txt", "dmidecode"),
+        ("dmidecode", "txt", "sudo dmidecode"),
         ("meminfo", "txt", "cat /proc/meminfo"),
         ("loadavg", "txt", "cat /proc/loadavg"),
         ("cpuinfo", "txt", "cat /proc/cpuinfo"),

--- a/ceph_monitoring/collect_info.py
+++ b/ceph_monitoring/collect_info.py
@@ -359,6 +359,7 @@ class NodeCollector(Collector):
                         speed = line.split(":")[1].strip()
                     if 'Duplex:' in line:
                         interface['duplex'] = line.split(":")[1].strip() == 'Full'
+            print "HOST: "+host+" DEV: "+dev+" SPEED: "+speed
 
             ok, data = check_output_ssh(host, self.opts, "iwconfig " + dev)
             if ok and 'Bit Rate=' in data:
@@ -366,7 +367,7 @@ class NodeCollector(Collector):
                 if 'Tx-Power=' in br1:
                     speed = br1.split('Tx-Power=')[0]
 
-            if speed is "Unknown!":
+            if speed == "Unknown!":
                 speed = None
 
             if speed is not None:

--- a/ceph_monitoring/collect_info.py
+++ b/ceph_monitoring/collect_info.py
@@ -366,6 +366,9 @@ class NodeCollector(Collector):
                 if 'Tx-Power=' in br1:
                     speed = br1.split('Tx-Power=')[0]
 
+            if speed is "Unknown!":
+                speed = None
+
             if speed is not None:
                 mults = {
                     'Kb/s': 125,

--- a/ceph_monitoring/collect_info.py
+++ b/ceph_monitoring/collect_info.py
@@ -77,7 +77,8 @@ def get_device_for_file(host, opts, fname):
     dev_str = dev_str.strip()
     dev_link = dev_str.strip().split("\n")[1].split()[0]
 
-    if dev_link == 'udev':
+    # This sets the right fname if the journal is a raw device. Ubuntu returns 'udev', while in SUSE 'devtmpfs' is returned
+    if dev_link == 'udev' or dev_link == "devtmpfs":
         dev_link = fname
 
     abs_path_cmd = '\'path="{0}" ;'.format(dev_link)

--- a/ceph_monitoring/collect_info.py
+++ b/ceph_monitoring/collect_info.py
@@ -319,7 +319,7 @@ class NodeCollector(Collector):
     run_alone = False
 
     node_commands = [
-        ("lshw", "xml", "lshw -xml"),
+        ("lshw", "xml", "sudo lshw -xml"),
         ("lsblk", "txt", "lsblk -a"),
         ("diskstats", "txt", "cat /proc/diskstats"),
         ("uname", "txt", "uname -a"),

--- a/ceph_monitoring/collect_info.py
+++ b/ceph_monitoring/collect_info.py
@@ -332,7 +332,7 @@ class NodeCollector(Collector):
         ("netdev", "txt", "cat /proc/net/dev"),
         ("ceph_conf", "txt", "cat /etc/ceph/ceph.conf"),
         ("uptime", "txt", "cat /proc/uptime"),
-        ("dmesg", "txt", "cat /var/log/dmesg"),
+        ("dmesg", "txt", "dmesg"),
         ("netstat", "txt", "netstat -nap")
     ]
 


### PR DESCRIPTION
With these changes, collect_info.py finishes successfully on SUSE and Ubuntu. There are still a few items to address (e.g. lshw on SUSE and NIC speed detection), but the output is usable.